### PR TITLE
Add swagger and redoc pages

### DIFF
--- a/src/docs.html
+++ b/src/docs.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css">
+        <link rel="shortcut icon" href="https://fastapi.tiangolo.com/img/favicon.png">
+        <title>RedditLoans - Swagger UI</title>
+    </head>
+    <body>
+        <div id="swagger-ui">
+        </div>
+        <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <!-- `SwaggerUIBundle` is now available on the page -->
+    <script>
+        const ui = SwaggerUIBundle({
+            url: '/api/openapi.json',
+        oauth2RedirectUrl: window.location.origin + '/docs/oauth2-redirect',
+            dom_id: '#swagger-ui',
+            presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset
+            ],
+            layout: "BaseLayout",
+            deepLinking: true
+        })
+    </script>
+    </body>
+</html>

--- a/src/redoc.html
+++ b/src/redoc.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>RedditLoans - ReDoc</title>
+        <!-- needed for adaptive design -->
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+        <link rel="shortcut icon" href="https://fastapi.tiangolo.com/img/favicon.png">
+        <!--
+        ReDoc doesn't change outer page styles
+        -->
+        <style>
+            body {
+            margin: 0;
+            padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <redoc spec-url="/api/openapi.json"></redoc>
+        <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    </body>
+</html>


### PR DESCRIPTION
These are direct copies of the auto-generated ones from fastapi,
except with the url for the openapi.json fixed. Fastapi gets
confused because Nginx is changing the path for the backend
compared to the frontend